### PR TITLE
  removes one stack installation

### DIFF
--- a/laas.rosinstall
+++ b/laas.rosinstall
@@ -3,10 +3,6 @@
     local-name: stacks/vision_visp
     version: master
 - git:
-    uri: git://github.com/laas/motion_analysis_mocap.git
-    local-name: stacks/motion_analysis_mocap
-    version: master
-- git:
     uri: git://github.com/stack-of-tasks/redundant_manipulator_control.git
     local-name: stacks/redundant_manipulator_control
     version: master


### PR DESCRIPTION
This commit removes the installation of this stacks : git://github.com/laas/motion_analysis_mocap.git
it is now available as a private repository for the LAAS gepetto team, and it will be available freely as binaries via RobotPKG.
